### PR TITLE
Update the session provider interface to comply with upcoming v2 Session 

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -12,8 +12,8 @@ type Orchestrator interface {
 	// Logger gets a logger.
 	Logger() log.Logger
 
-	// SessionProvider gets a session provider.
-	SessionProvider() session.Provider
+	// Session returns the session.
+	Session(opts ...session.SessionOpt) (session.Provider, error)
 
 	// SecretProvider gets a secret provider. An error is returned if a secret
 	// provider is not configured.

--- a/session/session.go
+++ b/session/session.go
@@ -7,28 +7,41 @@ import "net/http"
 //
 // Example:
 //
-//	session.Set(req, "idp.authenticated", "true")
+//	sess, _ := api.Session()
+//	_ = sess.SetString("idp.authenticated", "true")
+//	_ = sess.Save()
 type Provider interface {
 	// GetString returns a session value based on the provided key.
-	GetString(req *http.Request, key string) string
+	GetString(key string) (string, error)
 
-	// Get returns a session value based on the provided key.
-	Get(req *http.Request, key string) any
+	// SetString adds a key and the corresponding string value to the session data.
+	SetString(key string, value string) error
 
-	// Set sets a value on the session for the provided key.
-	Set(req *http.Request, key string, value any)
+	// Save saves all changes from the changelog to the underlying session store.
+	Save() error
 }
 
-// Session provides a session instance for an end-user. This interface is
-// typically only used for back-channel interactions that do not contain a
-// session cookie on the request.
-type Session interface {
-	// GetString returns a session value based on the provided key.
-	GetString(key string) string
+type Options struct {
+	Request *http.Request
+}
 
-	// Get returns a session value based on the provided key.
-	Get(key string) any
+// SessionOpt is an option that allows to configure retrieval of the session.
+//
+// Example:
+//
+//	sess, _ := api.Session(WithRequest(req))
+//	isAuth, _ := sess.GetString("idp.authenticated")
+type SessionOpt func(*Options)
 
-	// Set sets a value on the session for the provided key.
-	Set(key string, value any)
+// WithRequest is a SessionOpt that allows to retrieve a particular session with
+// a specific request.
+//
+// Example:
+//
+//	sess, _ := api.Session(WithRequest(req))
+//	isAuth, _ := sess.GetString("idp.authenticated")
+func WithRequest(req *http.Request) SessionOpt {
+	return func(o *Options) {
+		o.Request = req
+	}
 }


### PR DESCRIPTION
This PR updates the session.Provider interface to comply with upcoming changes to the v2 Session interface within Maverics.

In order to obtain the session of a particular request, we can obtain it using the API defined within `orchestrator.Orchestrator`. This abstracts the implementation of how the session is retrieved from the request to the implementor.

The new session attribute methods follow a more idiomatic go style where if an error occurs retrieving the attributes, it will be returned to be appropriately handled by the caller. 

We are also going to provide type specific getters and setters so the caller doesn't have to type cast the values. For now, we only support String values. We can expand this further in the future.

The new interface introduces a `Save() error` method which makes it the callers responsibility for persisting changes to the session state. Previously, this was done implicitly via the `Set` method.

If there is a need to retrieve a session for a specific request, the user can leverage the `session.WithRequest` option.