### PR TITLE
Add TAI to Orchestrator interface

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/strata-io/service-extension/router"
 	"github.com/strata-io/service-extension/secret"
 	"github.com/strata-io/service-extension/session"
+	"github.com/strata-io/service-extension/tai"
 )
 
 type Orchestrator interface {
@@ -32,4 +33,7 @@ type Orchestrator interface {
 
 	// Metadata gets the metadata associated with the Service Extension in use.
 	Metadata() map[string]any
+
+	// TAI gets a TAI provider.
+	TAI() tai.Provider
 }

--- a/tai/tai.go
+++ b/tai/tai.go
@@ -1,0 +1,26 @@
+package tai
+
+import "time"
+
+type Config struct {
+	// RSAPrivateKeyPEM is the pem-encoded RSA PKCS1 private key that will be used to
+	// sign the JWT.
+	RSAPrivateKeyPEM string
+
+	// Subject is the user's unique identifier. This value will be mapped to the
+	// JWT's 'sub' claim.
+	Subject string
+
+	// Lifetime is the duration of the token's lifetime. This value will be mapped
+	// to the JWT's 'exp' claim. The Lifetime should generally be set to match the
+	// lifetime of a user's session.
+	Lifetime time.Duration
+}
+
+// Provider provides the functionality required to securely interact with a
+// Maverics TAI module.
+type Provider interface {
+	// NewSignedJWT returns a signed JWT that the TAI module will consume in order
+	// to build its identity context.
+	NewSignedJWT(Config) (string, error)
+}


### PR DESCRIPTION
This PR adds a `TAI` method to the Orchestrator interface. This functionality enables the Orchestrator to securely interact with the Maverics TAI module.