### PR TITLE
Add ability to provide the `Context` for an instance of `Orchestrator`

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -54,6 +54,10 @@ type Orchestrator interface {
 	// If context is unavailable, nil will be returned.
 	Context() context.Context
 
+	// WithContext returns a shallow copy of an Orchestrator with the provided
+	// context.
+	WithContext(ctx context.Context) Orchestrator
+
 	// ServiceExtensionAssets exposes any assets that may have been bundled with the
 	// service extension.
 	ServiceExtensionAssets() bundle.SEAssets


### PR DESCRIPTION
**Description** <Describe what changed.>
This PR enables users of service extensions to set the context for the instance of `orchestrator.Orchestrator`. 

This enables SE developers to support tracing within their components, add lifecycles, add metadata, or anything else where a custom context is useful.

**Testing**
N/A

**Documentation** <Describe any documentation that was added.>
Comments.