### PR TITLE
Add WebLogic to Orchestrator interface

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/strata-io/service-extension/secret"
 	"github.com/strata-io/service-extension/session"
 	"github.com/strata-io/service-extension/tai"
+	"github.com/strata-io/service-extension/weblogic"
 )
 
 type Orchestrator interface {
@@ -44,6 +45,9 @@ type Orchestrator interface {
 
 	// TAI gets a TAI provider.
 	TAI() tai.Provider
+
+	// WebLogic gets a WebLogic provider.
+	WebLogic() weblogic.Provider
 
 	// Context gets the context associated with the Service Extension in use.
 	// This is an experimental feature and may not be available in all Service Extensions.

--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -21,10 +21,6 @@ type Orchestrator interface {
 	// Session returns the session.
 	Session(opts ...session.SessionOpt) (session.Provider, error)
 
-	// Cache returns a cache that can be used to store state across different service
-	// extensions.
-	Cache(namespace string, opts ...cache.Constraint) (cache.Cache, error)
-
 	// SecretProvider gets a secret provider. An error is returned if a secret
 	// provider is not configured.
 	SecretProvider() (secret.Provider, error)
@@ -37,17 +33,17 @@ type Orchestrator interface {
 	// the attribute provider is not found.
 	AttributeProvider(name string) (idfabric.AttributeProvider, error)
 
-	// Router gets a router.
-	Router() router.Router
-
 	// Metadata gets the metadata associated with the Service Extension in use.
 	Metadata() map[string]any
 
-	// TAI gets a TAI provider.
-	TAI() tai.Provider
+	// Router gets a router.
+	Router() router.Router
 
 	// App gets the App associated with the Service Extension in use.
 	App() (app.App, error)
+
+	// TAI gets a TAI provider.
+	TAI() tai.Provider
 
 	// Context gets the context associated with the Service Extension in use.
 	// This is an experimental feature and may not be available in all Service Extensions.
@@ -57,6 +53,10 @@ type Orchestrator interface {
 	// WithContext returns a shallow copy of an Orchestrator with the provided
 	// context.
 	WithContext(ctx context.Context) Orchestrator
+
+	// Cache returns a cache that can be used to store state across different service
+	// extensions.
+	Cache(namespace string, opts ...cache.Constraint) (cache.Cache, error)
 
 	// ServiceExtensionAssets exposes any assets that may have been bundled with the
 	// service extension.

--- a/weblogic/weblogic.go
+++ b/weblogic/weblogic.go
@@ -1,0 +1,26 @@
+package weblogic
+
+import (
+	"time"
+)
+
+type Config struct {
+	// RSAPrivateKeyPEM is the pem-encoded RSA PKCS1 private key that will be used to
+	// sign the JWT.
+	RSAPrivateKeyPEM string
+
+	// Subject is the user's unique identifier. This value will be mapped to the
+	// JWT's 'sub' claim.
+	Subject string
+
+	// Lifetime is the duration of the token's lifetime. This value will be mapped
+	// to the JWT's 'exp' claim. The Lifetime should generally be set to match the
+	// lifetime of a user's session.
+	Lifetime time.Duration
+}
+
+type Provider interface {
+	// NewSignedJWT returns a signed JWT that the WebLogic Identity Asserter module
+	// will consume in order to build its identity context.
+	NewSignedJWT(Config) (string, error)
+}


### PR DESCRIPTION
This PR adds a `WebLogic` method to the Orchestrator interface. This functionality enables the Orchestrator to securely interact with the Maverics WebLogic Identity Asserter module in a similar way to the [WebSphere TAI module](https://github.com/strata-io/service-extension/pull/18).