### PR TITLE
Add LDAP package with provider interface for bind DN retrieval

### DIFF
--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -1,0 +1,11 @@
+// Package ldap provides LDAP-specific interfaces for service extensions.
+package ldap
+
+import "context"
+
+// Provider is the interface for LDAP operations.
+type Provider interface {
+	// BindDN retrieves the bind DN from the context. It returns an empty string
+	// if no bind DN is present.
+	BindDN(ctx context.Context) string
+}

--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -5,7 +5,8 @@ import "context"
 
 // Provider is the interface for LDAP operations.
 type Provider interface {
-	// BindDN retrieves the bind DN from the context. It returns an empty string
-	// if no bind DN is present.
+	// BindDN retrieves the bind DN from the context. The context should be
+	// retrieved via the Orchestrator's Context() method (e.g., `api.Context()`).
+	// It returns an empty string if no bind DN is present.
 	BindDN(ctx context.Context) string
 }


### PR DESCRIPTION
This PR adds an `ldap` package to the service-extension library, providing an interface for LDAP provider operations. The package includes an `ldap.Provider` interface with a `BindDN` method that retrieves the bind DN from a context.