### PR TITLE
Move BindDN function to type to simplify usage

### DIFF
--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -3,10 +3,7 @@ package ldap
 
 import "context"
 
-// Provider is the interface for LDAP operations.
-type Provider interface {
-	// BindDN retrieves the bind DN from the context. The context should be
-	// retrieved via the Orchestrator's Context() method (e.g., `api.Context()`).
-	// It returns an empty string if no bind DN is present.
-	BindDN(ctx context.Context) string
-}
+// BindDN retrieves the bind DN from the context. The context should be
+// retrieved via the Orchestrator's Context() method (e.g., `api.Context()`).
+// It returns an empty string if no bind DN is present.
+type BindDN func(ctx context.Context) string


### PR DESCRIPTION
This PR is a follow-up to #45 to simplify usage of the BindDN function.