### PR TITLE
Add WithForceAuthentication login option to idfabric

### DIFF
--- a/idfabric/idfrabric.go
+++ b/idfabric/idfrabric.go
@@ -28,6 +28,7 @@ type LoginOptions struct {
 	Username             string
 	RedirectURL          string
 	SilentAuthentication bool
+	ForceAuthentication  bool
 	QueryParams          url.Values
 	GrantType            int
 	ROPCRequest          ROPCRequest
@@ -67,6 +68,19 @@ func WithQueryParam(k, v string) LoginOpt {
 func WithSilentAuthentication() LoginOpt {
 	return func(cfg *LoginOptions) {
 		cfg.SilentAuthentication = true
+	}
+}
+
+// WithForceAuthentication specifies to the IDP that the user must be actively
+// re-authenticated as part of the login, even if they already have an existing
+// session with the IDP.
+//
+// In the context of SAML, this option results in ForceAuthn="true" being set on
+// the AuthnRequest. In the context of OIDC, it corresponds to the
+// 'prompt=login' query parameter.
+func WithForceAuthentication() LoginOpt {
+	return func(cfg *LoginOptions) {
+		cfg.ForceAuthentication = true
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new `WithForceAuthentication` `LoginOpt` and corresponding `ForceAuthentication` field to `idfabric.LoginOptions`. This lets callers instruct the identity provider to actively re-authenticate the user during login even when a valid IDP session already exists. It is the counterpart to `WithSilentAuthentication`, and is documented to map to `ForceAuthn="true"` on the SAML `AuthnRequest` and to the `prompt=login` query parameter for OIDC, giving consumers a provider-agnostic way to force fresh authentication.

## Test Plan

The change extends the existing functional-options pattern (mirroring `WithSilentAuthentication`) and only adds a struct field plus an option constructor; it introduces no new runtime behavior in this package. Verified `go vet ./...`, `go build ./...`, and `go test ./...` pass cleanly on the root module. No unit tests exist for `idfabric` today, so none were added; downstream SAML/OIDC providers that consume `LoginOptions.ForceAuthentication` are responsible for exercising the end-to-end flow.

## JIRA

https://rubrik.atlassian.net/browse/STRATA-659

## Notes

This is an additive, backwards-compatible change: the new field defaults to `false`, preserving existing login behavior. Follow-up work is needed in the SAML and OIDC provider implementations to read `ForceAuthentication` and emit `ForceAuthn="true"` / `prompt=login` respectively.
